### PR TITLE
🐛 Fix bug with reading a saved theme

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -43,30 +43,43 @@ function getSystemTheme(): Theme {
     : 'light';
 }
 
+function getSavedTheme(): ThemeState | null {
+  const rawSavedTheme = localStorage.getItem('theme');
+
+  if (rawSavedTheme == null) {
+    return null;
+  }
+
+  try {
+    const savedTheme = JSON.parse(rawSavedTheme);
+
+    if (!isThemeState(savedTheme)) {
+      return null;
+    }
+
+    if (savedTheme.followSystem) {
+      return {
+        theme: getSystemTheme(),
+        followSystem: true,
+      };
+    } else {
+      return savedTheme;
+    }
+  } catch {
+    return null;
+  }
+}
+
 export const ThemeProvider = ({children}: Props) => {
   const [themeState, setThemeState] = useState<ThemeState>(() => {
-    const defaultSetting = {
+    const defaultTheme = {
       theme: getSystemTheme(),
       followSystem: true,
     };
 
-    const rawSavedTheme = localStorage.getItem('theme');
+    const savedTheme = getSavedTheme();
 
-    if (rawSavedTheme == null) {
-      return defaultSetting;
-    }
-
-    try {
-      const savedTheme = JSON.parse(rawSavedTheme);
-
-      if (isThemeState(savedTheme)) {
-        return savedTheme;
-      }
-    } catch {
-      return defaultSetting;
-    }
-
-    return defaultSetting;
+    return savedTheme ?? defaultTheme;
   });
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

This PR:

- Resolves a bug with when a saved theme is read. If the saved theme has `followSystem` as `true`, it will now get the theme from the system as soon as the app loads.

### Does this relate to an open issue?

No

### Checklist before merge

- [x] I have prefixed the name of the pull request with an emoji.
- [x] I have run `yarn tophat` locally to ensure that it builds correctly OR I have verified it builds with a deploy preview.

<!--

Common emojis:

- 📝 adding/updating content
- 🎨 design change
- 🐛 bugfix
- ✨ new feature
- 📦 updating dependencies
- 🔧 updating tooling/build settings
- 🛠️ refactored code
- 🔁 misc fix to trigger rebuild & deploy

See the [full list](https://gist.github.com/parmentf/035de27d6ed1dce0b36a) if these don't cut it
-->
