### PR TITLE
🛠️ Refactor recommended reading to use PostTile

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -50,12 +50,16 @@ exports.createPages = ({graphql, actions}) => {
         const pathPrefix = node.type === 'Post' ? 'blog' : 'projects';
 
         const recommendedReading = buildReadingList(
-          node,
-          nodes.filter(
-            (currentNode) =>
-              currentNode.type === node.type &&
-              currentNode.status === 'Published',
-          ),
+          nodes
+            .filter(function excludeUnpublishedNodes(currentNode) {
+              return (
+                currentNode.type === node.type &&
+                currentNode.status === 'Published'
+              );
+            })
+            .filter(function excludeCurrentNode(currentNode) {
+              return currentNode.slug !== node.slug;
+            }),
         );
 
         createPage({

--- a/gatsby-utils.js
+++ b/gatsby-utils.js
@@ -1,3 +1,5 @@
+const sampleSize = require('lodash.samplesize');
+
 const validateNode = (node) => {
   const name = node.internal.contentFilePath;
 
@@ -91,62 +93,24 @@ const validateNode = (node) => {
   enforceNodeFields(node);
 };
 
-// Found this at https://gomakethings.com/how-to-shuffle-an-array-with-vanilla-js/
-const shuffle = (array) => {
-  var currentIndex = array.length;
-  var temporaryValue, randomIndex;
-
-  // While there remain elements to shuffle...
-  while (0 !== currentIndex) {
-    // Pick a remaining element...
-    randomIndex = Math.floor(Math.random() * currentIndex);
-    currentIndex -= 1;
-
-    // And swap it with the current element.
-    temporaryValue = array[currentIndex];
-    array[currentIndex] = array[randomIndex];
-    array[randomIndex] = temporaryValue;
-  }
-
-  return array;
-};
-
-const chooseRandomElements = (original, list, numberOfElements = 3) => {
-  // slice it so it passes by copy, not be reference
-  const shuffledList = shuffle(list.slice());
-  const chosenElements = [];
-  shuffledList.forEach((element) => {
-    if (
-      chosenElements.length >= numberOfElements ||
-      element.slug === original.slug
-    ) {
-      return;
-    }
-    chosenElements.push(element);
-  });
-
-  return chosenElements;
-};
-
-const buildReadingList = (item, items) => {
-  const pickedItems = chooseRandomElements(item, items);
-  const preparedItems = pickedItems
-    .map((item) => ({
-      link: {
-        slug: item.slug,
-        label: item.title,
-      },
-      date: item['date'],
+const buildReadingList = (nodes) => {
+  const pickedNodes = sampleSize(nodes, 3);
+  const preparedNodes = pickedNodes
+    .map((node) => ({
+      slug: node.slug,
+      label: node.title,
+      isLinkPost: node.link != null,
+      date: node.date,
     }))
-    .sort((firstPair, secondPair) => {
-      if (new Date(firstPair.date) > new Date(secondPair.date)) {
+    .sort((firstNode, secondNode) => {
+      if (new Date(firstNode.date) > new Date(secondNode.date)) {
         return -1;
       } else {
         return 1;
       }
     });
 
-  return preparedItems;
+  return preparedNodes;
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "autoprefixer": "^10.4.14",
+    "lodash.samplesize": "^4.2.0",
     "netlify-plugin-cache": "^1.0.3",
     "postcss": "^8.4.21",
     "prettier": "^2.8.1",

--- a/src/components/FeaturedTile/FeaturedTile.tsx
+++ b/src/components/FeaturedTile/FeaturedTile.tsx
@@ -1,10 +1,9 @@
 import classnames from 'classnames';
 import React from 'react';
 
-import {PostTile} from '../PostTile';
-import {Icon, Image} from '../../components';
+import {Image} from '../../components';
 
-import {Link, Meta} from '../../components';
+import {Link} from '../../components';
 import {Routes} from '../../utils';
 
 interface Props {

--- a/src/components/PostTile/PostTile.tsx
+++ b/src/components/PostTile/PostTile.tsx
@@ -4,21 +4,33 @@ import {Link} from '../../components';
 import {Routes} from '../../utils';
 
 export interface Props {
-  node: Mdx;
+  slug?: string | null;
+  title?: string | null;
+  date?: string | null;
+  type?: string;
+  isLinkPost?: boolean;
   className?: string;
 }
 
-export const PostTile = ({node}: Props) => {
-  if (node.slug == null) {
+export const PostTile = ({
+  slug,
+  title,
+  date,
+  isLinkPost,
+  type = 'Post',
+}: Props) => {
+  if (slug == null) {
     return null;
   }
+
+  const route = type === 'Post' ? Routes.blogPost : Routes.project;
 
   return (
     <div>
       <Link
-        url={Routes.blogPost(node.slug)}
+        url={route(slug)}
         icon={
-          node.link
+          isLinkPost
             ? {
                 position: 'trailing',
                 name: 'link',
@@ -26,11 +38,9 @@ export const PostTile = ({node}: Props) => {
             : undefined
         }
       >
-        {node.title}
+        {title}
       </Link>
-      <div className="text-text-muted dark:text-text-muted-dark">
-        {node.date}
-      </div>
+      <div className="text-text-muted dark:text-text-muted-dark">{date}</div>
     </div>
   );
 };

--- a/src/components/ReadingList/ReadingList.tsx
+++ b/src/components/ReadingList/ReadingList.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {Link} from '../../components';
-import {Routes} from '../../utils';
+import {PostTile} from '../../components';
 
 export interface Props {
   recommendedReading: RecommendedReading[];
@@ -17,18 +16,18 @@ export function ReadingList({type, recommendedReading}: Props) {
     type === 'Post' ? 'article' : 'design'
   }, you might enjoy one of these:`;
 
-  const route = type === 'Post' ? Routes.blogPost : Routes.project;
-
-  const makePairMarkup = ({link: {slug, label}, date}: RecommendedReading) => {
-    return (
-      <div className="" key={label}>
-        <Link url={route(slug)}>{label}</Link>
-        <div className="text-text-muted dark:text-text-muted-dark">{date}</div>
-      </div>
-    );
-  };
-
-  const markup = recommendedReading.map(makePairMarkup);
+  const markup = recommendedReading.map(
+    ({slug, label, date, isLinkPost}: RecommendedReading) => (
+      <PostTile
+        key={slug}
+        title={label}
+        slug={slug}
+        date={date}
+        type={type}
+        isLinkPost={isLinkPost}
+      />
+    ),
+  );
 
   return (
     <div className="space-y-medium w-full">

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -58,9 +58,8 @@ type Mdx = {
 };
 
 interface RecommendedReading {
-  link: {
-    slug: string;
-    label: string;
-  };
+  slug: string;
+  label: string;
   date: string;
+  isLinkPost: boolean;
 }

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -54,7 +54,13 @@ function BlogPage({data}: Props) {
                   <h2>{year}</h2>
                   <div className="space-y-normal">
                     {posts.map((node) => (
-                      <PostTile node={node} key={node.slug!} />
+                      <PostTile
+                        key={node.slug!}
+                        title={node.title}
+                        slug={node.slug}
+                        isLinkPost={node.link != null}
+                        date={node.date}
+                      />
                     ))}
                   </div>
                 </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,7 +33,13 @@ function IndexPage({data}: IndexPageProps) {
         <FeaturedTile node={featuredPost} />
         <div className="space-y-normal">
           {posts.map((node: Mdx) => (
-            <PostTile node={node} key={node.slug!} />
+            <PostTile
+              key={node.slug!}
+              slug={node.slug}
+              title={node.title}
+              date={node.date}
+              isLinkPost={node.link != null}
+            />
           ))}
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8447,6 +8447,11 @@ lodash.mergewith@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
+lodash.samplesize@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.samplesize/-/lodash.samplesize-4.2.0.tgz#460762fbb2b342290517499e90d51586db465ff9"
+  integrity sha512-1ZhKV7/nuISuaQdxfCqrs4HHxXIYN+0Z4f7NMQn2PHkxFZJGavJQ1j/paxyJnLJmN2ZamNN6SMepneV+dCgQTA==
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"


### PR DESCRIPTION
### What does this PR do?

This PR:

- Refactors the function that chooses the recommended reading to use the lodash `.sampleSize()` method instead of a custom function
- Refactors the `<PostTile />` component to accept named props instead of just `node`
- Refactors the recommended reading list to use `<PostTile />`–this means that link posts within recommended reading list now properly include the trailing 🔗 icon

### Does this relate to an open issue?

Closes https://github.com/thetrevorharmon/thetrevorharmon.com/issues/187

### Checklist before merge

- [x] I have prefixed the name of the pull request with an emoji.
- [x] I have run `yarn tophat` locally to ensure that it builds correctly OR I have verified it builds with a deploy preview.

<!--

Common emojis:

- 📝 adding/updating content
- 🎨 design change
- 🐛 bugfix
- ✨ new feature
- 📦 updating dependencies
- 🔧 updating tooling/build settings
- 🛠️ refactored code
- 🔁 misc fix to trigger rebuild & deploy

See the [full list](https://gist.github.com/parmentf/035de27d6ed1dce0b36a) if these don't cut it
-->
