### PR TITLE
🐛 Prevent double entries in reading list

### DIFF
--- a/gatsby-utils.js
+++ b/gatsby-utils.js
@@ -149,7 +149,18 @@ const buildReadingList = (node, nodes) => {
     // only choose from nodes that have opted in to be recommended
     // this does not apply to the curated picks, only unpublished nodes
     // are unavailable in that context
-    availableNodes.filter((node) => node.includeInReadingList),
+    availableNodes
+      .filter((node) => node.includeInReadingList)
+      // do not pick nodes that have already been manually included in the recommended reading
+      .filter((node) => {
+        if (node.relatedReading == null) {
+          return true;
+        }
+
+        const isInCuratedPicks = node.relatedReading.includes(node.slug);
+
+        return !isInCuratedPicks;
+      }),
     3,
   );
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug that resulted in duplicate entries in the reading list. Now curated picks are filtered out when choosing random picks, preventing this issue.

### Does this relate to an open issue?

No

### Checklist before merge

- [x] I have prefixed the name of the pull request with an emoji.
- [x] I have run `yarn tophat` locally to ensure that it builds correctly OR I have verified it builds with a deploy preview.

<!--

Common emojis:

- 📝 adding/updating content
- 🎨 design change
- 🐛 bugfix
- ✨ new feature
- 📦 updating dependencies
- 🔧 updating tooling/build settings
- 🛠️ refactored code
- 🔁 misc fix to trigger rebuild & deploy

See the [full list](https://gist.github.com/parmentf/035de27d6ed1dce0b36a) if these don't cut it
-->
